### PR TITLE
Use 1.0.6-ci.93 package directly from Nuget.org

### DIFF
--- a/WpfApp2274WorkaroundTest/WpfApp2274WorkaroundTest.csproj
+++ b/WpfApp2274WorkaroundTest/WpfApp2274WorkaroundTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WPF2274Workaround" Version="1.0.0" />
+    <PackageReference Include="WPF2274Workaround" Version="1.0.6-ci.93" />
     <PackageReference Include="Unity" Version="4.0.1" />
   </ItemGroup>
 

--- a/WpfApp2274WorkaroundTest/nuget.config
+++ b/WpfApp2274WorkaroundTest/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget" value="../wpf2274/bin/Debug" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
I published a package to NuGet.org directly to make this easier - https://www.nuget.org/packages/WPF2274Workaround/1.0.6-ci.93. 